### PR TITLE
open file normally if checking out locally

### DIFF
--- a/lua/gh_review/diff.lua
+++ b/lua/gh_review/diff.lua
@@ -516,8 +516,8 @@ local function show_diff(path, left_content, right_content)
   local right_bufnr
   if state.is_local_checkout() then
     -- path is repo-root-relative; make it absolute so :edit works from a subdirectory.
-    local git_dir = vim.fs.find(".git", { upward = true })[1]
-    local abs_path = git_dir and (vim.fs.dirname(git_dir) .. "/" .. path) or path
+    local root = vim.fs.root(0, ".git")
+    local abs_path = root and (root .. "/" .. path) or path
     vim.cmd("edit " .. vim.fn.fnameescape(abs_path))
     right_bufnr = vim.api.nvim_get_current_buf()
   else

--- a/lua/gh_review/diff.lua
+++ b/lua/gh_review/diff.lua
@@ -447,11 +447,13 @@ local function setup_diff_buffer(bufnr, name, path, content, real_file)
     vim.bo[bufnr].modifiable = false
   end
 
-  -- Set syntax highlighting from path extension.
-  local ext = vim.fn.fnamemodify(path, ":e")
-  if ext and ext ~= "" then
-    local syn = syntax_map[ext] or ext
-    vim.cmd("setlocal syntax=" .. syn)
+  -- Skip for real files: :edit already set up filetype/Treesitter/LSP, which this would clobber.
+  if not real_file then
+    local ext = vim.fn.fnamemodify(path, ":e")
+    if ext and ext ~= "" then
+      local syn = syntax_map[ext] or ext
+      vim.cmd("setlocal syntax=" .. syn)
+    end
   end
 
   local winid = vim.fn.bufwinid(bufnr)
@@ -513,7 +515,10 @@ local function show_diff(path, left_content, right_content)
   -- Set up the right (head) buffer.
   local right_bufnr
   if state.is_local_checkout() then
-    vim.cmd("edit " .. vim.fn.fnameescape(path))
+    -- path is repo-root-relative; make it absolute so :edit works from a subdirectory.
+    local git_dir = vim.fs.find(".git", { upward = true })[1]
+    local abs_path = git_dir and (vim.fs.dirname(git_dir) .. "/" .. path) or path
+    vim.cmd("edit " .. vim.fn.fnameescape(abs_path))
     right_bufnr = vim.api.nvim_get_current_buf()
   else
     right_bufnr = vim.fn.bufnr(right_name, true)
@@ -749,6 +754,14 @@ function M.close_diff()
       vim.cmd("diffoff")
       if not state.is_local_checkout() then
         vim.cmd("enew")
+      else
+        -- Real file buffer stays open: drop our keymaps so `q`/`K` don't shadow
+        -- macro recording / LSP hover. ponytail: list mirrors setup_diff_buffer.
+        for _, key in ipairs({ "gt", "gc", "]t", "[t", "gs", "gf", "gF", "q", "K" }) do
+          pcall(vim.keymap.del, "n", key, { buffer = right })
+        end
+        pcall(vim.keymap.del, "x", "gc", { buffer = right })
+        pcall(vim.keymap.del, "x", "gs", { buffer = right })
       end
     end
   end

--- a/lua/gh_review/diff.lua
+++ b/lua/gh_review/diff.lua
@@ -458,6 +458,17 @@ local function setup_diff_buffer(bufnr, name, path, content, real_file)
 
   local winid = vim.fn.bufwinid(bufnr)
   if winid ~= -1 then
+    -- Real files keep their window after the diff closes, so remember the
+    -- options we override here and restore them in close_diff. Capture once,
+    -- before the first override, so we never save already-diffed values.
+    if real_file and state.get_saved_win_opts() == nil then
+      state.set_saved_win_opts({
+        winid = winid,
+        foldmethod = vim.wo[winid].foldmethod,
+        signcolumn = vim.wo[winid].signcolumn,
+        number = vim.wo[winid].number,
+      })
+    end
     vim.wo[winid].foldmethod = "diff"
     vim.wo[winid].signcolumn = "yes"
     vim.wo[winid].number = false
@@ -756,12 +767,22 @@ function M.close_diff()
         vim.cmd("enew")
       else
         -- Real file buffer stays open: drop our keymaps so `q`/`K` don't shadow
-        -- macro recording / LSP hover. ponytail: list mirrors setup_diff_buffer.
+        -- macro recording / LSP hover. List mirrors setup_diff_buffer.
         for _, key in ipairs({ "gt", "gc", "]t", "[t", "gs", "gf", "gF", "q", "K" }) do
           pcall(vim.keymap.del, "n", key, { buffer = right })
         end
         pcall(vim.keymap.del, "x", "gc", { buffer = right })
         pcall(vim.keymap.del, "x", "gs", { buffer = right })
+        -- Restore the window options the diff overrode. :diffoff leaves
+        -- foldmethod as "diff" (we set it before :diffthis), and it never
+        -- touches signcolumn/number, so the real file would otherwise keep
+        -- diff folding, a forced signcolumn, and hidden line numbers.
+        local wo = state.get_saved_win_opts()
+        if wo and wo.winid == winid then
+          vim.wo[winid].foldmethod = wo.foldmethod
+          vim.wo[winid].signcolumn = wo.signcolumn
+          vim.wo[winid].number = wo.number
+        end
       end
     end
   end
@@ -769,6 +790,7 @@ function M.close_diff()
   state.set_left_bufnr(-1)
   state.set_right_bufnr(-1)
   state.set_diff_path("")
+  state.set_saved_win_opts(nil)
 
   -- Return focus to the files list
   local fb = state.get_files_bufnr()

--- a/lua/gh_review/diff.lua
+++ b/lua/gh_review/diff.lua
@@ -434,29 +434,16 @@ local syntax_map = {
   mm = "objcpp",
 }
 
-local function setup_diff_buffer(bufnr, name, path, content, editable)
-  if editable then
-    vim.bo[bufnr].buftype = "acwrite"
+local function setup_diff_buffer(bufnr, name, path, content, real_file)
+  if real_file then
+    -- Real file on disk: don't touch buftype or content
+    vim.bo[bufnr].bufhidden = "hide"
   else
     vim.bo[bufnr].buftype = "nofile"
-  end
-  vim.bo[bufnr].bufhidden = "wipe"
-  vim.bo[bufnr].swapfile = false
-  vim.bo[bufnr].modifiable = true
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
-  if editable then
-    vim.bo[bufnr].modified = false
-    vim.b[bufnr].gh_review_file_path = path
-    vim.b[bufnr].gh_review_file_mtime = vim.fn.getftime(path)
-    vim.api.nvim_create_autocmd("BufWriteCmd", {
-      buffer = bufnr,
-      callback = function() write_buffer(bufnr, path) end,
-    })
-    vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold" }, {
-      buffer = bufnr,
-      callback = function() check_external_change(bufnr) end,
-    })
-  else
+    vim.bo[bufnr].bufhidden = "wipe"
+    vim.bo[bufnr].swapfile = false
+    vim.bo[bufnr].modifiable = true
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
     vim.bo[bufnr].modifiable = false
   end
 
@@ -524,8 +511,14 @@ local function show_diff(path, left_content, right_content)
   end
 
   -- Set up the right (head) buffer.
-  local right_bufnr = vim.fn.bufnr(right_name, true)
-  vim.cmd("noautocmd buffer " .. right_bufnr)
+  local right_bufnr
+  if state.is_local_checkout() then
+    vim.cmd("edit " .. vim.fn.fnameescape(path))
+    right_bufnr = vim.api.nvim_get_current_buf()
+  else
+    right_bufnr = vim.fn.bufnr(right_name, true)
+    vim.cmd("noautocmd buffer " .. right_bufnr)
+  end
   state.set_right_bufnr(right_bufnr)
   setup_diff_buffer(right_bufnr, right_name, path, right_content, state.is_local_checkout())
 
@@ -671,9 +664,8 @@ local function fetch_contents(base_oid, head_oid, path)
     end)
   end
 
-  -- Fetch right (head) content
-  if change_type == "DELETED" then
-    right_content = {}
+  -- Fetch right (head) content (skip for local checkout -- we open the real file)
+  if change_type == "DELETED" or state.is_local_checkout() then
     fetches_done = fetches_done + 1
   else
     fetch_git_content(head_oid, path, function(content)
@@ -749,13 +741,15 @@ function M.close_diff()
     end
   end
 
-  -- Replace right diff buffer with an empty buffer
+  -- For real file buffers just turn off diff; for scratch buffers replace with empty
   if right ~= -1 and vim.fn.bufexists(right) == 1 then
     local winid = vim.fn.bufwinid(right)
     if winid ~= -1 then
       vim.fn.win_gotoid(winid)
       vim.cmd("diffoff")
-      vim.cmd("enew")
+      if not state.is_local_checkout() then
+        vim.cmd("enew")
+      end
     end
   end
 

--- a/lua/gh_review/state.lua
+++ b/lua/gh_review/state.lua
@@ -56,6 +56,10 @@ local thread_winid = -1
 local diff_path = ""
 local is_local_checkout = false
 
+-- Window options (foldmethod/signcolumn/number) saved before a local-checkout
+-- diff overrides them on the real file's window, so close_diff can restore them.
+local saved_win_opts = nil
+
 -- ------- Getters / Setters -------
 
 function M.get_pr_id() return pr_id end
@@ -103,6 +107,9 @@ function M.set_diff_path(path) diff_path = path end
 
 function M.is_local_checkout() return is_local_checkout end
 function M.set_local_checkout(val) is_local_checkout = val end
+
+function M.get_saved_win_opts() return saved_win_opts end
+function M.set_saved_win_opts(opts) saved_win_opts = opts end
 
 -- ------- PR data loading -------
 
@@ -246,6 +253,7 @@ function M.reset()
   thread_winid = -1
   diff_path = ""
   is_local_checkout = false
+  saved_win_opts = nil
 end
 
 return M

--- a/test/test_diff_logic.lua
+++ b/test/test_diff_logic.lua
@@ -337,4 +337,38 @@ h.run_test("Virtual text truncates long bodies to 60 chars", function()
   vim.cmd("bwipeout! " .. right)
 end)
 
+h.run_test("close_diff restores real-file window options for local checkout", function()
+  state.reset()
+
+  -- A local checkout opens the real file on disk as the right/head buffer.
+  local tmpfile = "/tmp/gh_review_test_wo_restore.lua"
+  vim.fn.writefile({ "local a = 1", "return a" }, tmpfile)
+  vim.cmd("edit " .. tmpfile)
+  local rwin = vim.api.nvim_get_current_win()
+  local rbuf = vim.api.nvim_get_current_buf()
+
+  -- Genuine pre-diff options, then what setup_diff_buffer saved + then applied.
+  vim.wo[rwin].foldmethod = "indent"
+  vim.wo[rwin].signcolumn = "auto"
+  vim.wo[rwin].number = true
+  state.set_saved_win_opts({ winid = rwin, foldmethod = "indent", signcolumn = "auto", number = true })
+  vim.wo[rwin].foldmethod = "diff"
+  vim.wo[rwin].signcolumn = "yes"
+  vim.wo[rwin].number = false
+
+  state.set_right_bufnr(rbuf)
+  state.set_diff_path("gh_review_test_wo_restore.lua")
+  state.set_local_checkout(true)
+
+  diff.close_diff()
+
+  h.assert_equal("indent", vim.wo[rwin].foldmethod, "foldmethod should be restored")
+  h.assert_equal("auto", vim.wo[rwin].signcolumn, "signcolumn should be restored")
+  h.assert_true(vim.wo[rwin].number, "number should be restored")
+  h.assert_true(state.get_saved_win_opts() == nil, "saved opts should be cleared")
+
+  vim.fn.delete(tmpfile)
+  pcall(vim.cmd, "bwipeout! " .. rbuf)
+end)
+
 h.write_results("/tmp/gh_review_test_diff_logic.txt")


### PR DESCRIPTION
When reviewing with the branch already checked out, I'd like to have access to all my normal nvim functionality, especially my LSP, outline.nvim, etc. 

This PR opens the right-hand side of the diff locally when the reviewed branch is checked out locally.